### PR TITLE
`fly.toml`: use http_service.checks for health checks

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -17,30 +17,22 @@ DJANGO_ALLOWED_HOSTS = "splashcat.fly.dev,splashcat.ink"
 DEBUG = "False"
 SENTRY_DSN = "https://9babb5ac79274bed8e3c56a222b44ab6@o4505055559352320.ingest.sentry.io/4505055561449472"
 
-[[services]]
+[http_service]
 internal_port = 8000
-protocol = "tcp"
 force_https = true
 auto_stop_machines = true
 auto_start_machines = true
 min_machines_running = 0
-processes = ["app"]
-[[services.ports]]
-handlers = ["http"]
-port = 80
-force_https = true
-[[services.ports]]
-handlers = ["tls", "http"]
-port = "443"
-#[[services.http_checks]]
-#grace_period = "5s"
-#interval = "5s"
-#method = "get"
-#path = "/"
-#protocol = "http"
-#restart_limit = 5
-#timeout = "3s"
-#tls_skip_verify = false
+
+[[http_service.checks]]
+grace_period = "5s"
+interval = "5s"
+method = "get"
+path = "/"
+protocol = "http"
+restart_limit = 5
+timeout = "5s"
+tls_skip_verify = false
 
 [[statics]]
 guest_path = "/code/staticfiles"


### PR DESCRIPTION
Continuing from https://community.fly.io/t/unable-to-access-app/13738/10, this should get your deployments sorted out (assuming CI picks up the most recent flyctl release, because it relies on a feature that was released *\*checks phone\** five minutes ago 😅)